### PR TITLE
Support all float values

### DIFF
--- a/src/main/scala/scalang/node/ScalaTermEncoder.scala
+++ b/src/main/scala/scalang/node/ScalaTermEncoder.scala
@@ -232,8 +232,16 @@ class ScalaTermEncoder(peer: Symbol) extends OneToOneEncoder with Logging with I
   }
 
   def writeFloat(buffer : ChannelBuffer, d : Double) {
-    buffer.writeByte(70)
-    buffer.writeLong(java.lang.Double.doubleToLongBits(d))
+    if (d.isNaN) {
+      writeAtom(buffer, 'nan)
+    } else if (d.isPosInfinity) {
+      writeAtom(buffer, 'infinity)
+    } else if (d.isNegInfinity) {
+      writeAtom(buffer, Symbol("-infinity"))
+    } else {
+      buffer.writeByte(70)
+      buffer.writeLong(java.lang.Double.doubleToLongBits(d))
+    }
   }
 
   def writeStringFloat(buffer : ChannelBuffer, d : Double) {


### PR DESCRIPTION
writeFloat can send three values that erlang cannot understand (the error on the erlang side is quite spectacular).

This patch encodes the three special values as atoms as there's apparently no equivalent in erlang.
