### PR TITLE
Send monitor exit if not alive

### DIFF
--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -173,7 +173,7 @@ trait Node extends ClusterListener with ClusterPublisher {
   def ping(node : Symbol, timeout : Long) : Boolean
   def nodes : Set[Symbol]
   def makeRef : Reference
-  def isAlive(pid : Pid) : Boolean
+  def isAlive(pidOrProc : Any) : Boolean
   def shutdown
   def timer : HashedWheelTimer
 }
@@ -894,8 +894,8 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     }
   }
 
-  def isAlive(pid : Pid) : Boolean = {
-    process(pid) match {
+  def isAlive(pidOrProc : Any) : Boolean = {
+    process(pidOrProc) match {
       case Some(_) => true
       case None => false
     }

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -795,12 +795,7 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     case pid : Pid =>
       pid.node == name
     case regName : Symbol =>
-      whereis(regName) match {
-        case Some(pid : Pid) =>
-          pid.node == name
-        case None =>
-          false
-      }
+      true
     case (regName : Symbol, node : Symbol) =>
       node == name
   }

--- a/src/main/scala/scalang/node/ProcessAdapter.scala
+++ b/src/main/scala/scalang/node/ProcessAdapter.scala
@@ -145,8 +145,12 @@ trait ProcessAdapter extends ExitListenable with SendListenable with LinkListena
 
   def monitor(monitored : Any) : Reference = {
     val m = Monitor(self, monitored, makeRef)
-    for (listener <- monitorListeners) {
-      listener.deliverMonitor(m)
+    if (state != 'alive) {
+      m.monitorExit('noproc)
+    } else {
+      for (listener <- monitorListeners) {
+        listener.deliverMonitor(m)
+      }
     }
     m.ref
   }
@@ -156,7 +160,13 @@ trait ProcessAdapter extends ExitListenable with SendListenable with LinkListena
   }
   
   def registerMonitor(monitoring : Pid, ref : Reference): Monitor = {
-    registerMonitor(Monitor(monitoring, self, ref))
+    val m = Monitor(monitoring, self, ref)
+    if (state != 'alive) {
+      m.monitorExit('noproc)
+      m
+    } else {
+      registerMonitor(m)
+    }
   }
 
   private def registerMonitor(m : Monitor): Monitor = {

--- a/src/test/scala/scalang/NodeSpec.scala
+++ b/src/test/scala/scalang/NodeSpec.scala
@@ -219,5 +219,24 @@ class NodeSpec extends SpecificationWithJUnit {
        node.isAlive(monitorProc) must ==(true)
    }
 
+     "deliver local monitor exit for unregistered process" in {
+       node = Node(Symbol("scala@localhost"), cookie)
+       val mbox = node.spawnMbox
+       val ref = mbox.monitor('foo)
+       Thread.sleep(100)
+       mbox.receive must ==('DOWN, ref, 'process, 'foo, 'noproc)
+     }
+
+     "deliver remote monitor exit for unregistered process" in {
+       node = Node(Symbol("scala@localhost"), cookie)
+       val mbox = node.spawnMbox('mbox)
+       val scala = node.spawnMbox('scala)
+       erl = Escript("monitor.escript")
+       val remotePid = mbox.receive.asInstanceOf[Pid]
+       node.send(remotePid, ('monitor, 'foo))
+       val remoteRef = scala.receive.asInstanceOf[Reference]
+       scala.receive must ==(('down, 'noproc))
+     }
+
   }
 }


### PR DESCRIPTION
If a node attempts to monitor a registered process by name in a Scalang node and no process of that name exists, Scalang silently ignores the request. Instead, Scalang must send a monitor exit message back ("A 'DOWN' message will be sent to the monitoring process if Item dies, if Item does not exist, or if the connection is lost to the node which Item resides on." from http://erlang.org/doc/man/erlang.html#monitor-2)
