### PR TITLE
Fix monitoring

### DIFF
--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -556,8 +556,11 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     }
 
     if (isLocal(monitored)) {
-      for (p <- process(monitored)) {
-        p.registerMonitor(monitoring, ref)
+      process(monitored) match {
+        case Some(p : ProcessAdapter) =>
+          p.registerMonitor(monitoring, ref)
+        case None =>
+          monitorExit(monitor, 'noproc)
       }
     } else {
       getOrConnectAndSend(nodeOf(monitored), MonitorMessage(monitoring, monitored, ref), { channel =>
@@ -575,9 +578,10 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     }
 
     if (!isLocal(monitoring) && !isLocal(monitored)) {
-      log.warn("Try to monitor between non-local pids: %s -> %s", monitoring, monitored)
+      log.warn("Try to monitor between non-local pids: %s -> %s (%s)", monitoring, monitored, ref)
       return
     }
+
     log.debug("pids %s", processes.keys.toList)
     process(monitored) match {
       case Some(p) =>
@@ -586,8 +590,13 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
         if (!isLocal(monitored))
           monitors.getOrElseUpdate(channel, new NonBlockingHashSet[Monitor]).add(monitor)
       case None =>
-        if (!isLocal(monitored))
+        if (isLocal(monitored)) {
+          log.warn("Try to monitor non-live process: %s -> %s (%s)", monitoring, monitored, ref)
+          val monitor = Monitor(monitoring, monitored, ref)
+          monitorExit(monitor, 'noproc)
+        } else {
           monitors.getOrElseUpdate(channel, new NonBlockingHashSet[Monitor]).add(Monitor(monitoring, monitored, ref))
+        }
     }
   }
 

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -173,7 +173,7 @@ trait Node extends ClusterListener with ClusterPublisher {
   def ping(node : Symbol, timeout : Long) : Boolean
   def nodes : Set[Symbol]
   def makeRef : Reference
-  def isAlive(pid : Pid) : Boolean
+  def isAlive(pidOrProc : Any) : Boolean
   def shutdown
   def timer : HashedWheelTimer
 }
@@ -894,8 +894,8 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     }
   }
 
-  def isAlive(pid : Pid) : Boolean = {
-    process(pid) match {
+  def isAlive(pidOrProc : Any) : Boolean = {
+    process(pidOrProc) match {
       case Some(_) => true
       case None => false
     }

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -795,12 +795,7 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
     case pid : Pid =>
       pid.node == name
     case regName : Symbol =>
-      whereis(regName) match {
-        case Some(pid : Pid) =>
-          pid.node == name
-        case None =>
-          false
-      }
+      true
     case (regName : Symbol, node : Symbol) =>
       node == name
   }

--- a/src/main/scala/scalang/node/ProcessAdapter.scala
+++ b/src/main/scala/scalang/node/ProcessAdapter.scala
@@ -111,14 +111,16 @@ trait ProcessAdapter extends ExitListenable with SendListenable with LinkListena
   def exit(reason : Any) {
     if (state != 'alive) return
     state = 'dead
+
+    // Exit listeners first, so that process is removed from table.
+    for(e <- exitListeners) {
+      e.handleExit(self, reason)
+    }
     for (link <- links) {
       link.break(reason)
     }
     for (m <- monitors.values) {
       m.monitorExit(reason)
-    }
-    for(e <- exitListeners) {
-      e.handleExit(self, reason)
     }
     cleanup
   }

--- a/src/main/scala/scalang/node/ProcessAdapter.scala
+++ b/src/main/scala/scalang/node/ProcessAdapter.scala
@@ -95,7 +95,7 @@ abstract class ProcessHolder(ctx : ProcessContext) extends ProcessAdapter {
 }
 
 trait ProcessAdapter extends ExitListenable with SendListenable with LinkListenable with MonitorListenable with Instrumented with Logging {
-  @volatile var state = 'alive
+  var state = 'alive
   def self : Pid
   def fiber : Fiber
   def referenceCounter : ReferenceCounter
@@ -109,8 +109,10 @@ trait ProcessAdapter extends ExitListenable with SendListenable with LinkListena
   def handleMonitorExit(monitored : Any, ref : Reference, reason : Any)
   
   def exit(reason : Any) {
-    if (state != 'alive) return
-    state = 'dead
+    synchronized {
+      if (state != 'alive) return
+      state = 'dead
+    }
 
     // Exit listeners first, so that process is removed from table.
     for(e <- exitListeners) {
@@ -165,7 +167,12 @@ trait ProcessAdapter extends ExitListenable with SendListenable with LinkListena
     for (listener <- monitorListeners) {
       m.addMonitorListener(listener)
     }
-    monitors.put(m.ref, m)
+    synchronized {
+      if (state != 'alive)
+        m.monitorExit('noproc)
+      else
+        monitors.put(m.ref, m)
+    }
     m
   }
   

--- a/src/test/scala/scalang/NodeSpec.scala
+++ b/src/test/scala/scalang/NodeSpec.scala
@@ -219,5 +219,24 @@ class NodeSpec extends SpecificationWithJUnit {
        node.isAlive(monitorProc) must ==(true)
    }
 
+     "deliver local monitor exit for unregistered process" in {
+       node = Node(Symbol("scala@localhost"), cookie)
+       val mbox = node.spawnMbox
+       val ref = mbox.monitor('foo)
+       Thread.sleep(100)
+       mbox.receive must ==('DOWN, ref, 'process, 'foo, 'noproc)
+     }
+
+     "deliver remote monitor exit for unregistered process" in {
+       node = Node(Symbol("scala@localhost"), cookie)
+       val mbox = node.spawnMbox('mbox)
+       val scala = node.spawnMbox('scala)
+       erl = Escript("monitor.escript")
+       val remotePid = mbox.receive.asInstanceOf[Pid]
+       node.send(remotePid, ('monitor, 'foo))
+       val remoteRef = scala.receive.asInstanceOf[Reference]
+       scala.receive must ==(('down, 'noproc))
+     }
+
   }
 }


### PR DESCRIPTION
This set of patches closes all known race conditions preventing the sending of monitor exit messages for running processes and correctly sends monitor exit messages when an attempt is made to monitor a process that does not exist.

I have run 10,000 handleCall queries, each of which does 'throw new Exception("oops")'. Without these changes, I would receive almost none of the expected monitor exit messages. With them, I received all 10,000. The final commit, that adds synchronize blocks to ensure we don't add a monitor to the monitors variable if we have already exited (and sends a monitor exit instead) fixed the last 4 out of 10,000 message failures. 
