### PR TITLE
Allow subclasses to override exit correctly

### DIFF
--- a/src/main/scala/scalang/node/ProcessAdapter.scala
+++ b/src/main/scala/scalang/node/ProcessAdapter.scala
@@ -42,7 +42,7 @@ abstract class ProcessHolder(ctx : ProcessContext) extends ProcessAdapter {
         } catch {
           case e : Throwable =>
             log.error(e, "An error occurred in actor %s", process)
-            exit(e.getMessage)
+            process.exit(e.getMessage)
         }
       }
     }
@@ -56,7 +56,7 @@ abstract class ProcessHolder(ctx : ProcessContext) extends ProcessAdapter {
       } catch {
         case e : Throwable =>
           log.error(e, "An error occurred during handleExit in actor %s", this)
-          exit(e.getMessage)
+          process.exit(e.getMessage)
       }
     }
   })
@@ -69,7 +69,7 @@ abstract class ProcessHolder(ctx : ProcessContext) extends ProcessAdapter {
       } catch {
         case e : Throwable =>
           log.error(e, "An error occurred during handleMonitorExit in actor %s", this)
-          exit(e.getMessage)
+          process.exit(e.getMessage)
       }
     }
   })


### PR DESCRIPTION
Prior to 28d3dd1dc2cf3ec8d7fae0df43c6e43acc375d7b subclasses of Service and Process could override exit(reason : Any) to cleanup stateful resources. This patch restores that ability.

It might be neater to have an onExit(reason : Any) variant, with a no-op implementation in the base class  to guard against overriding this function without calling the superclass.
