### PR TITLE
Avoid race condition when handling epmd responses

### DIFF
--- a/src/main/scala/scalang/epmd/Epmd.scala
+++ b/src/main/scala/scalang/epmd/Epmd.scala
@@ -21,6 +21,7 @@ import netty.bootstrap._
 import netty.channel._
 import socket.nio._
 import overlock.threadpool._
+import java.util.concurrent.Callable
 
 object Epmd {
   val defaultPort = 4369
@@ -65,19 +66,27 @@ class Epmd(val host : String, val port : Int) {
   }
 
   def alive(portNo : Int, nodeName : String) : Option[Int] = {
-    channel.write(AliveReq(portNo,nodeName))
-    val response = handler.response.call.asInstanceOf[AliveResp]
-    if (response.result == 0) {
-      Some(response.creation)
+    var response: Callable[Any] = null
+    handler.synchronized {
+      response = handler.response
+      channel.write(AliveReq(portNo,nodeName))
+    }
+    val aliveResponse = response.call.asInstanceOf[AliveResp]
+    if (aliveResponse.result == 0) {
+      Some(aliveResponse.creation)
     } else {
-      error("Epmd response was: " + response.result)
+      sys.error("Epmd response was: " + aliveResponse.result)
       None
     }
   }
 
   def lookupPort(nodeName : String) : Option[Int] = {
-    channel.write(PortPleaseReq(nodeName))
-    handler.response.call match {
+    var response: Callable[Any] = null
+    handler.synchronized {
+      response = handler.response
+      channel.write(PortPleaseReq(nodeName))
+    }
+    response.call match {
       case PortPleaseResp(portNo, _) => Some(portNo)
       case PortPleaseError(_) => None
     }


### PR DESCRIPTION
There is a race condition which can occur when handling responses
from epmd if the response from the daemon comes back before the
callback object is added to EpmdHandler.queue. This has been
verified by adding a Thread.sleep() between the call to
channel.write() and handler.response(). Also ensure we can handle
multiple responses in epmd (instead of pulling all queued responses).
