### PR TITLE
Update String code for Java 7 compatibility.

### DIFF
--- a/src/test/scala/scalang/node/ScalaTermDecoderSpec.scala
+++ b/src/test/scala/scalang/node/ScalaTermDecoderSpec.scala
@@ -1,0 +1,16 @@
+package scalang.node
+
+import org.specs.SpecificationWithJUnit
+import org.jboss.netty.buffer.ChannelBuffers
+import java.nio.charset.Charset
+
+class ScalaTermDecoderSpec extends SpecificationWithJUnit {
+  "ScalaTermDecoder" should {
+    "decode a string" in {
+      val buffer = ChannelBuffers.copiedBuffer("abc", Charset.forName("utf-8"))
+      val decoded = ScalaTermDecoder.fastString(buffer, 3)
+      decoded must ==("abc")
+      decoded.length must ==(3)
+    }
+  }
+}


### PR DESCRIPTION
Scalang uses unsafe operations to avoid String copies. This adds a unit
test for term decoding and fixes a bug when using scalang with Java 7.
