### PR TITLE
Remove CappedFiberFactory from Node.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jetlang</groupId>
             <artifactId>jetlang</artifactId>
-            <version>0.2.10-capped</version>
+            <version>0.2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.netty</groupId>
@@ -117,7 +117,6 @@
         </executions>
 	      <configuration>
           <args>
-            <arg>-optimise</arg>
             <arg>-unchecked</arg>
             <arg>-deprecation</arg>
           </args>

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -29,7 +29,6 @@ import overlock.atomicmap._
 import org.jetlang._
 import core._
 import java.io._
-import fibers.CappedFiberFactory
 import core.BatchExecutorImpl
 import netty.handler.execution.ExecutionHandler
 import scala.collection.JavaConversions._
@@ -42,6 +41,7 @@ import org.jboss.netty.logging._
 import netty.util.HashedWheelTimer
 import com.yammer.metrics.scala._
 import java.nio.channels.ClosedChannelException
+import org.jetlang.fibers.PoolFiberFactory
 
 object Node {
   val random = SecureRandom.getInstance("SHA1PRNG")
@@ -201,7 +201,7 @@ class ErlangNode(val name : Symbol, val cookie : String, config : NodeConfig) ex
   val pidCount = new AtomicInteger(0)
   val pidSerial = new AtomicInteger(0)
   val executor = poolFactory.createActorPool
-  val factory = new CappedFiberFactory(executor, 1000)
+  val factory = new PoolFiberFactory(executor)
   val executionHandler = new ExecutionHandler(poolFactory.createExecutorPool)
   val server = new ErlangNodeServer(this,config.typeFactory, config.typeEncoder, config.typeDecoder)
   val localEpmd = Epmd("localhost")


### PR DESCRIPTION
Remove the use of CappedFiberFactory (seeing deadlocks under load).
Switch to the latest upstream jetlang dependency.
