### PR TITLE
Stop using ElasticBlockingQueue

### DIFF
--- a/src/main/scala/scalang/epmd/Epmd.scala
+++ b/src/main/scala/scalang/epmd/Epmd.scala
@@ -25,8 +25,8 @@ import java.util.concurrent.Callable
 
 object Epmd {
   val defaultPort = 4369
-  lazy val bossPool = ThreadPool.instrumentedElastic("scalang.epmd", "boss", 1, 20)
-  lazy val workerPool = ThreadPool.instrumentedElastic("scalang.epmd", "worker", 1, 20)
+  lazy val bossPool = ThreadPool.instrumentedFixed("scalang.epmd", "boss", 20)
+  lazy val workerPool = ThreadPool.instrumentedFixed("scalang.epmd", "worker", 20)
 
   def apply(host : String) : Epmd = {
     val port = Option(System.getenv("ERL_EPMD_PORT")).map(_.toInt).getOrElse(defaultPort)


### PR DESCRIPTION
ElasticBlockingQueue will drop messages when no thread is polling the
queue. These changes replace ElasticBlockingQueue with
java.util.concurrent.LinkedBlockingQueue.
