### PR TITLE
Improve support for Erlang cookies

### DIFF
--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -40,6 +40,9 @@ object Node {
   val random = SecureRandom.getInstance("SHA1PRNG")
 
   def apply(name : String) : Node = apply(Symbol(name))
+  def apply(name : String, tpf : ThreadPoolFactory) : Node = apply(Symbol(name), tpf)
+  def apply(name : String, listener : ClusterListener) : Node = apply(Symbol(name), listener)
+  def apply(name : String, nodeConfig : NodeConfig) : Node = apply(Symbol(name), nodeConfig)
   def apply(name : String, cookie : String) : Node = apply(Symbol(name), cookie)
   def apply(name : String, cookie : String, tpf : ThreadPoolFactory) : Node = apply(Symbol(name), cookie, tpf)
   def apply(name : String, cookie : String, listener : ClusterListener) : Node = apply(Symbol(name), cookie, listener)
@@ -47,6 +50,15 @@ object Node {
 
   def apply(name : Symbol) =
     new ErlangNode(name, findOrGenerateCookie, NodeConfig(new DefaultThreadPoolFactory, None))
+
+  def apply(name : Symbol, tpf : ThreadPoolFactory) =
+    new ErlangNode(name, findOrGenerateCookie, NodeConfig(tpf, None))
+
+  def apply(name : Symbol, listener : ClusterListener) =
+    new ErlangNode(name, findOrGenerateCookie, NodeConfig(new DefaultThreadPoolFactory, Some(listener)))
+
+  def apply(name : Symbol, nodeConfig : NodeConfig) =
+    new ErlangNode(name, findOrGenerateCookie, nodeConfig)
 
   def apply(name : Symbol, cookie : String) =
     new ErlangNode(name, cookie, NodeConfig(new DefaultThreadPoolFactory, None))

--- a/src/main/scala/scalang/Node.scala
+++ b/src/main/scala/scalang/Node.scala
@@ -35,6 +35,10 @@ import netty.util.HashedWheelTimer
 import com.yammer.metrics.scala._
 import org.jetlang.fibers.PoolFiberFactory
 import com.boundary.logula.Logging
+import scala.collection.JavaConverters._
+import java.nio.file.{ Path, Files }
+import java.nio.file.attribute.PosixFilePermission
+
 
 object Node {
   val random = SecureRandom.getInstance("SHA1PRNG")
@@ -83,6 +87,9 @@ object Node {
     } else {
       val cookie = randomCookie
       writeCookie(file, cookie)
+      val permissions = setAsJavaSet(Set(PosixFilePermission.OWNER_READ))
+      try
+        Files.setPosixFilePermissions(file.toPath, permissions)
       cookie
     }
   }


### PR DESCRIPTION
The way how `Node` objects could be instantiated currently does not allow the `cookie` parameter to be omitted and it to be read from `~/.erlang.cookie` or generated when arguments other than `name` are specified.  This pull request introduces the alternative method bodies to achieve this.  It also implements an attempt to set the proper file permissions as expected per [the Erlang documentation](https://www.erlang.org/doc/reference_manual/distributed.html#security).